### PR TITLE
Migrate actions and fix code snippets

### DIFF
--- a/snippets/ConfigTable.jsx
+++ b/snippets/ConfigTable.jsx
@@ -1,8 +1,57 @@
+export const ConfigField = ({
+  title,
+  type,
+  cel = false,
+  defaultValue = false,
+  required = false,
+  children,
+}) => {
+  const id = `config-${title.replace(/\.|\s|\*/g, "_")}`;
+  return (
+    <div className="field pt-2.5 pb-5 my-2.5 border-gray-50 dark:border-gray-800/50 border-b" style={{ scrollMarginTop: '120px' }} id={id}>
+      <div className="flex font-mono group/param-head param-head break-all relative">
+        <div className="flex-1 flex content-start py-0.5 mr-5">
+          <div className="flex items-center flex-wrap gap-2">
+            <div class="absolute -top-1.5">
+              <a href={`#${id}`} className="-ml-10 flex items-center opacity-0 border-0 group-hover/param-head:opacity-100 py-2 [.expandable-content_&amp;]:-ml-[2.1rem]" aria-label="Navigate to header">
+                ​<div className="w-6 h-6 rounded-md flex items-center justify-center shadow-sm text-gray-400 dark:text-white/50 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover::rightness-150 bg-white ring-1 ring-gray-400/30 dark:ring-gray-700/25 hover:ring-gray-400/60 dark:hover:ring-white/20">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="gray" height="12px" viewBox="0 0 576 512"><path d="M0 256C0 167.6 71.6 96 160 96h72c13.3 0 24 10.7 24 24s-10.7 24-24 24H160C98.1 144 48 194.1 48 256s50.1 112 112 112h72c13.3 0 24 10.7 24 24s-10.7 24-24 24H160C71.6 416 0 344.4 0 256zm576 0c0 88.4-71.6 160-160 160H344c-13.3 0-24-10.7-24-24s10.7-24 24-24h72c61.9 0 112-50.1 112-112s-50.1-112-112-112H344c-13.3 0-24-10.7-24-24s10.7-24 24-24h72c88.4 0 160 71.6 160 160zM184 232H392c13.3 0 24 10.7 24 24s-10.7 24-24 24H184c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>
+                </div>
+              </a>
+            </div>
+            <div className="font-semibold text-primary dark:text-primary-light overflow-wrap-anywhere">{title}</div>
+            <div className="inline items-center gap-2 text-xs font-medium [&_div]:inline [&_div]:mr-2 [&_div]:leading-5 [&_a]:inline [&_a]:mr-2 [&_a]:leading-5">
+              {type && (<div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
+                <span className="text-gray-600 dark:text-gray-200 !font-medium">{type}</span>
+              </div>)}
+              {defaultValue && (
+                <div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
+                  <span class="text-gray-400 dark:text-gray-500">default:</span>
+                  <span className="text-gray-600 dark:text-gray-200 !font-medium">{defaultValue}</span>
+                </div>
+              )}
+              {required && (<div className="px-2 py-0.5 rounded-md bg-red-100/50 dark:bg-red-400/10 whitespace-nowrap">
+                <span className="text-red-600 dark:text-red-300 !font-medium">Required</span>
+              </div>)}
+              {cel && (<a className="px-2 py-0.5 rounded-md !border-none bg-blue-100/50 dark:bg-blue-400/10 whitespace-nowrap" href="/traffic-policy/concepts/cel-interpolation">
+                <span className="text-blue-600 dark:text-blue-300 !font-medium">Supports CEL</span>
+              </a>)}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-4 prose-sm prose-gray dark:prose-invert [&_.prose>p:first-child]:mt-0 [&_.prose>p:last-child]:mb-0">
+        {children}
+      </div>
+    </div>
+  );
+};
 
 export const ConfigItem = ({
   title,
   type,
   cel = false,
+  defaultValue = false,
   required = false,
   children,
 }) => {
@@ -14,17 +63,29 @@ export const ConfigItem = ({
           <div className="flex items-center gap-2">
             <div class="absolute -top-1.5">
               <a href={`#${id}`} className="-ml-10 flex items-center opacity-0 border-0 group-hover/param-head:opacity-100 py-2 [.expandable-content_&amp;]:-ml-[2.1rem]" aria-label="Navigate to header">
-                ​<div className="w-6 h-6 rounded-md flex items-center justify-center shadow-sm text-gray-400 dark:text-white/50 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover:brightness-150 bg-white ring-1 ring-gray-400/30 dark:ring-gray-700/25 hover:ring-gray-400/60 dark:hover:ring-white/20">
+                ​<div className="w-6 h-6 rounded-md flex items-center justify-center shadow-sm text-gray-400 dark:text-white/50 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover::rightness-150 bg-white ring-1 ring-gray-400/30 dark:ring-gray-700/25 hover:ring-gray-400/60 dark:hover:ring-white/20">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="gray" height="12px" viewBox="0 0 576 512"><path d="M0 256C0 167.6 71.6 96 160 96h72c13.3 0 24 10.7 24 24s-10.7 24-24 24H160C98.1 144 48 194.1 48 256s50.1 112 112 112h72c13.3 0 24 10.7 24 24s-10.7 24-24 24H160C71.6 416 0 344.4 0 256zm576 0c0 88.4-71.6 160-160 160H344c-13.3 0-24-10.7-24-24s10.7-24 24-24h72c61.9 0 112-50.1 112-112s-50.1-112-112-112H344c-13.3 0-24-10.7-24-24s10.7-24 24-24h72c88.4 0 160 71.6 160 160zM184 232H392c13.3 0 24 10.7 24 24s-10.7 24-24 24H184c-13.3 0-24-10.7-24-24s10.7-24 24-24z"></path></svg>
                 </div>
               </a>
             </div>
-            <span className="font-semibold text-primary dark:text-primary-light overflow-wrap-anywhere">{title}</span>
-            {type && (<span className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 text-gray-600 dark:text-gray-200 font-medium break-all">
-              <span>{type}</span>
-            </span>)}
-            {required && (<span className="px-2 py-0.5 rounded-md bg-red-100/50 dark:bg-red-400/10 text-red-600 dark:text-red-300 font-medium whitespace-nowrap">Required</span>)}
-            {cel && (<a className="px-2 py-0.5 rounded-md !border-none bg-blue-100/50 dark:bg-blue-400/10 text-blue-600 dark:text-blue-300 font-medium whitespace-nowrap" href="/traffic-policy/concepts/cel-interpolation">Supports CEL</a>)}
+            <div className="font-semibold text-primary dark:text-primary-light overflow-wrap-anywhere">{title}</div>
+            <div className="inline items-center gap-2 text-xs font-medium [&_div]:inline [&_div]:mr-2 [&_div]:leading-5 [&_a]:inline [&_a]:mr-2 [&_a]:leading-5">
+              {type && (<div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
+                <span className="text-gray-600 dark:text-gray-200 !font-medium">{type}</span>
+              </div>)}
+              {defaultValue && (
+                <div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
+                  <span class="text-gray-400 dark:text-gray-500">default:</span>
+                  <span className="text-gray-600 dark:text-gray-200 !font-medium">{defaultValue}</span>
+                </div>
+              )}
+              {required && (<div className="px-2 py-0.5 rounded-md bg-red-100/50 dark:bg-red-400/10 whitespace-nowrap">
+                <span className="text-red-600 dark:text-red-300 !font-medium">Required</span>
+              </div>)}
+              {cel && (<a className="px-2 py-0.5 rounded-md !border-none bg-blue-100/50 dark:bg-blue-400/10 whitespace-nowrap" href="/traffic-policy/concepts/cel-interpolation">
+                <span className="text-blue-600 dark:text-blue-300 !font-medium">Supports CEL</span>
+              </a>)}
+            </div>
           </div>
         </div>
       </div>

--- a/traffic-policy/actions/add-headers.mdx
+++ b/traffic-policy/actions/add-headers.mdx
@@ -1,21 +1,195 @@
 ---
-title: Add Headers
+title: Add Headers Action
+sidebarTitle: Add Headers
+description: Add headers to an HTTP request or response before it is delivered upstream or back to the client.
 ---
-import ActionBehavior from "/snippets/traffic-policy/actions/add-headers/behavior.mdx";
-import ActionConfig from "/snippets/traffic-policy/actions/add-headers/config.mdx";
-import ActionExamples from "/snippets/traffic-policy/actions/add-headers/examples/index.mdx";
-import ActionOverview from "/snippets/traffic-policy/actions/add-headers/index.mdx";
-import ActionVariables from "/snippets/traffic-policy/actions/add-headers/variables.mdx";
-import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
+import { ConfigField } from "/snippets/ConfigTable.jsx";
 
+The Add Headers action enables you to add custom headers to an HTTP request or 
+response before delivery to the upstream service or client. This is useful 
+for attaching metadata like request identifiers, applying security controls, or 
+adjusting how applications process traffic.
 
+## Configuration Reference
 
-<ActionOverview />
-<ActionConfig />
-<ActionBehavior />
-<ActionExamples />
+The [Traffic Policy](/traffic-policy/) configuration reference for this action.
+
+### Supported Phases
+
+`on_http_request`, `on_http_response`
+
+### Type
+
+`add-headers`
+
+### Configuration Fields
+
+<ConfigField title="headers" type="object" cel={true}>
+  Map of header key to header value to be added.
+
+  Minimum `1`, Maximum `10`.
+</ConfigField>
+
+## Behavior
+
+When configured in the `on_http_request` phase, this action will add the specified headers to incoming http requests before reaching the upstream server. When
+configured in the `on_http_response` phase, the specified headers are added to the http response from the upstream server.
+
+### Addition Only
+
+This action will only add headers to the request or response. If the header already exists
+it will append another header with the same key unless it is the `host` header,
+see [Special Cases](#special-cases).
+
+To replace or remove headers use the [`remove-headers`](/traffic-policy/actions/remove-headers) action then
+add the header with the desired value.
+
+### Case Sensitivity
+
+Header keys added through this action are normalized to lowercase per the [HTTP/2 specification](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2).
+
+### Ordering
+
+Since actions are run in the order they are specified, to modify headers that have been added by other actions you must place this action
+after them in your traffic policy document.
+
+### Special Cases
+
+- Adding the `host` header override the existing value instead of appending another header.
+- You may not add or remove the `user-agent` header.
+- You may not use this action to add the `ngrok-skip-browser-warning` header to skip the ngrok browser warning on free accounts. For more information, check out the [free plan limits guide](/pricing-limits/free-plan-limits#removing-the-interstitial-page).
+
+## Examples
+
+### Adding Client IP Headers to all HTTP requests
+
+The following [Traffic Policy](/traffic-policy/)
+configuration will add the client IP address to all HTTP requests.
+
+#### Example Traffic Policy Document
+
+<CodeGroup>
+```yaml policy.yml highlight={4-7}
+on_http_request:
+  - actions:
+    - type: "add-headers"
+      config:
+        headers:
+          x-client-ip: "${conn.client_ip}"
+```
+```json policy.json highlight={5-12}
+{
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "add-headers",
+          "config": {
+            "headers": {
+              "x-client-ip": "${conn.client_ip}"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+For this example, we are assuming that ngrok is pointing at the upstream service
+https://httpbin.org and we are adding the following header to all requests:
+
+- `x-client-ip` with the value `${conn.client_ip}` to demonstrate the use of
+  CEL interpolation to include the client IP address.
+
+#### Example Request
+
+```bash
+$ curl -i https://httpbin.ngrok.app/get
+```
+
+```http
+HTTP/2 200 OK
+content-type: application/json
+
+{
+  "headers": {
+    "X-Client-Ip": "2600:1700:4fa6:1a00:2051:938:7373:5563",
+  }
+}
+```
+
+### Adding headers to an HTTP response
+
+The following [Traffic Policy](/traffic-policy/)
+configuration will add headers to the response from the upstream service when
+the method is `GET` and the URL starts with `/status/200`.
+
+#### Example Traffic Policy Document
+
+<CodeGroup>
+```yaml policy.yml highlight={6-10}
+on_http_response:
+  - expressions:
+      - "req.method == "GET" && req.url.path.startsWith("/status/200")"
+    actions:
+      - type: "add-headers"
+        config:
+          headers:
+            x-custom-header: "my-custom-value"
+            x-string-interpolation-example: "started at ${conn.ts.start}"
+```
+```json policy.json highlight={8-16}
+{
+  "on_http_response": [
+    {
+      "expressions": [
+        "req.method == \"GET\" && req.url.path.startsWith(\"/status/200\")"
+      ],
+      "actions": [
+        {
+          "type": "add-headers",
+          "config": {
+            "headers": {
+              "x-custom-header": "my-custom-value",
+              "x-string-interpolation-example": "started at ${conn.ts.start}"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+For this example, we are assuming that ngrok is pointing at the upstream service
+https://httpbin.org and we will be adding two headers:
+
+- `x-custom-header` with the value `my-custom-value`
+- `x-string-interpolation-example` with the value `started at ${conn.ts.start}`
+  to demonstrate the use of CEL interpolation to include the request connection
+  start time.
+
+### Example Request
+
+```bash
+$ curl -i https://httpbin.ngrok.app/status/200
+```
+
+```http
+HTTP/2 200 OK
+x-custom-header: my-custom-value
+x-string-interpolation-example: started at 2024-07-13T00:10:16Z
+```
 
 ## Action Result Variables
 
-<ActionVariablesDescription />
-<ActionVariables />
+The following variables are made available for use in subsequent expressions and
+CEL interpolations after the action has run. Variable values will only apply
+to the last action execution, results are not concatenated.
+
+<ConfigField title="actions.ngrok.add_headers.headers_added" type="object">
+  <p>Map of headers that were added by the action.</p>
+</ConfigField>

--- a/traffic-policy/actions/basic-auth.mdx
+++ b/traffic-policy/actions/basic-auth.mdx
@@ -1,21 +1,190 @@
 ---
-title: Basic Auth
+title: Basic Auth Action
+sidebarTitle: Basic Auth
+description: Enforce HTTP Basic Auth on your endpoints.
 ---
-import ActionBehavior from "/snippets/traffic-policy/actions/basic-auth/behavior.mdx";
-import ActionConfig from "/snippets/traffic-policy/actions/basic-auth/config.mdx";
-import ActionExamples from "/snippets/traffic-policy/actions/basic-auth/examples/index.mdx";
-import ActionOverview from "/snippets/traffic-policy/actions/basic-auth/index.mdx";
-import ActionVariables from "/snippets/traffic-policy/actions/basic-auth/variables.mdx";
-import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
+import { ConfigField } from "/snippets/ConfigTable.jsx";
 
+The Basic Auth action enables you to enforce HTTP Basic Auth on your endpoints. Requests with a valid username and password will be sent to
+your upstream service, all others will be rejected with a `401 Unauthorized` response.
 
+## Configuration Reference
 
-<ActionOverview />
-<ActionConfig />
-<ActionBehavior />
-<ActionExamples />
+This is the [Traffic Policy](/traffic-policy/) configuration
+reference for this action.
+
+### Supported Phases
+
+`on_http_request`
+
+### Type
+
+`basic-auth`
+
+### Configuration Fields
+
+<ConfigField title="credentials" type="array of strings" required={true} cel={true}>
+  <p>A list of up to 10 allowed <code>username:password</code> credential pairs.</p>
+  <p>Password must be at least <code>8</code> characters and no more than <code>128</code> characters.</p>
+</ConfigField>
+
+<ConfigField title="realm" type="string" required={false} defaultValue="ngrok">
+  <p>The HTTP realm of the request as per <a href="https://datatracker.ietf.org/doc/html/rfc7235">RFC 7235</a>.</p>
+</ConfigField>
+
+<ConfigField title="enforce" type="bool" required={false} defaultValue="true">
+  If <code>false</code>, continue to the next action even if basic authentication failed. 
+  
+  This is useful for handling fall-through, debugging, and testing purposes.
+</ConfigField>
+
+## Behavior
+
+The **basic-auth** action enforces HTTP Basic Authentication on incoming requests, as specified
+in [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235). When a request is received, the action
+verifies the request by validating against a known set of `user:password` credentials. If the
+verification is successful, the action allows the request to continue through the action chain and
+finally to your application; if verification fails, the request will be terminated with a
+`401 Unauthorized` response.
+
+### Additional Restrictions
+
+You can specify up to 10 `username:password` pairs. The password must be at least
+8 characters and no more than 128 characters. Including multiple colons in the `username:password`
+pair will result in the first colon being treated as the delimiter between the username and password.
+Realm cannot exceed 128 characters, and cannot contain non-ASCII characters.
+
+### Verification Process
+
+- **HTTP Authentication**: The action validates incoming HTTP requests to confirm they contain the required `Authorization` header, in the form of `Authorization: Basic <credentials>`, where `<credentials>` is the Base64 encoding of username and password joined by a single colon `:`.
+- **Request Handling**: If the authentication is successful, the request is forwarded to the next action. If the authentication fails, it will return to user a `401` response, which will prompt the user to provide a correct set of credentials.
+- **Configurable Enforcement**: By default, authentication failures result in 401s. However, setting `enforce: false` allows unauthenticated requests to proceed, while logging the authentication result. This option is for debugging and testing.
+
+### Secret Handling and Encryption
+
+All secrets used for basic authentication are encrypted at config validation. When ngrok processes a request, the secret is decrypted.
+
+### Using CEL in credentials
+
+You can use CEL interpolation in credentials, but the expression must stay properly scoped. A CEL expression can:
+
+- produce the entire credential,
+- produce the whole username or password, or
+- produce part of the username or password.
+
+If the expression does not produce the entire credential, you must include the `:` separator literally, and the expression itself cannot introduce another colon.
+
+#### Valid patterns
+
+- `${CEL_EXPRESSION}` - Entire credential is dynamic
+- `${CEL_EXPRESSION}:password` - Dynamic username, literal password
+- `${CEL_EXPRESSION}:${CEL_EXPRESSION}` - Both username and password are dynamic
+- `user-prefix${CEL_EXPRESSION}:password` - Part of the username is dynamic, literal password
+
+#### Invalid patterns
+
+- `${CEL_EXPRESSION}password` - Missing colon separator between username and password
+- `user-prefix${CEL_EXPRESSION}password-suffix` - Missing colon separator between username and password
+
+## Examples
+
+### Basic Example
+
+The following [Traffic Policy](/traffic-policy/)
+configuration is an example configuration of the `basic-auth` action.
+
+#### Example Traffic Policy Document
+
+<CodeGroup>
+```yaml policy.yml highlight={3-9}
+on_http_request:
+  - actions:
+    - type: "basic-auth"
+      config:
+        realm: "sample-realm"
+        credentials:
+          - "user:password1"
+          - "admin:password2"
+        enforce: true
+    - type: "custom-response"
+      config:
+        status_code: 200
+        headers:
+          content-type: "text/plain"
+        body: "Successfully Authenticated!"
+```
+```json policy.json highlight={5-15}
+{
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "basic-auth",
+          "config": {
+            "realm": "sample-realm",
+            "credentials": [
+              "user:password1",
+              "admin:password2"
+            ],
+            "enforce": true
+          }
+        },
+        {
+          "type": "custom-response",
+          "config": {
+            "status_code": 200,
+            "headers": {
+              "content-type": "text/plain"
+            },
+            "body": "Successfully Authenticated!"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+### Example Request
+
+First, base64 encode the `username:password` pair.
+`user:password1` becomes `dXNlcjpwYXNzd29yZDE=`
+
+```bash
+$ curl --request GET \
+  --url http://example-api.ngrok.app/ \
+  --header 'Authorization: Basic dXNlcjpwYXNzd29yZDE=`'
+```
+
+```http
+HTTP/2 200 OK
+content-type: text/html
+Successfully Authenticated!
+...
+```
+
+In this example, we are sending a request to our API with a valid set of credentials in
+the `Authorization` header with the `Basic` prefix and getting back a `200 OK`
+response.
+
+You can try it without the header, and you will receive a `401 Unauthorized` prompt
+instead.
 
 ## Action Result Variables
 
-<ActionVariablesDescription />
-<ActionVariables />
+The following variables are made available for use in subsequent expressions and
+CEL interpolations after the action has run. Variable values will only apply
+to the last action execution, results are not concatenated.
+
+<ConfigField title="actions.ngrok.basic_auth.credentials.presented" type="bool" required={false}>
+  <p>Whether there were Basic Auth credentials presented in the Authorization header.</p>
+</ConfigField>
+
+<ConfigField title="actions.ngrok.basic_auth.credentials.username" type="string" required={false}>
+  <p>The username of the credentials presented.</p>
+</ConfigField>
+
+<ConfigField title="actions.ngrok.basic_auth.credentials.authorized" type="bool" required={false}>
+  <p>Whether the presented basic auth credentials were authorized for this request.</p>
+</ConfigField>

--- a/traffic-policy/actions/circuit-breaker.mdx
+++ b/traffic-policy/actions/circuit-breaker.mdx
@@ -1,21 +1,164 @@
 ---
-title: Circuit Breaker
+title: Circuit Breaker Action
+sidebarTitle: Circuit Breaker
+description: Prevent overload and maintain system reliability by rejecting requests when errors and volume exceed set thresholds.
 ---
-import ActionBehavior from "/snippets/traffic-policy/actions/circuit-breaker/behavior.mdx";
-import ActionConfig from "/snippets/traffic-policy/actions/circuit-breaker/config.mdx";
-import ActionExamples from "/snippets/traffic-policy/actions/circuit-breaker/examples/index.mdx";
-import ActionOverview from "/snippets/traffic-policy/actions/circuit-breaker/index.mdx";
-import ActionVariables from "/snippets/traffic-policy/actions/circuit-breaker/variables.mdx";
-import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
+
+import { ConfigField } from "/snippets/ConfigTable.jsx";
+
+The Circuit Breaker Traffic Policy action helps you maintain system reliability 
+by rejecting requests when the error rate and request volume within a rolling 
+window exceed defined thresholds. It pauses traffic temporarily to allow the 
+system to recover and automatically re-evaluates upstream health before 
+resuming.
+
+## Configuration Reference
+
+The [Traffic Policy](/traffic-policy/) configuration reference for this action.
+
+### Supported Phases
+
+`on_http_request`
+
+### Type
+
+`circuit-breaker`
+
+### Configuration Fields
+
+<ConfigField title="error_threshold" type="float" required={true} defaultValue="0.5">
+  Threshold percentage of errors that must be met before requests are
+  rejected. 
+
+  Must be a value between `0.0` and `1.0`.
+</ConfigField>
+
+<ConfigField title="volume_threshold" type="integer" defaultValue="10">
+  Number of requests in a rolling window before checking the error
+  threshold. 
+
+  Must be a number between `1` and `2,000,000,000`.
+</ConfigField>
+
+<ConfigField title="window_duration" type="duration" defaultValue="10s">
+  Number of seconds in the rolling window that metrics are retained for.
+
+  Must be a value between `1s` and `2m`.
+</ConfigField>
+
+<ConfigField title="tripped_duration" type="duration" defaultValue="10s">
+  Number of seconds the system waits after rejecting a request before
+  re-evaluating upstream health. 
+
+  Must be a value between `1s` and `2m`.
+</ConfigField>
+
+<ConfigField title="num_buckets" type="integer">
+  Number of buckets that metrics are divided into within the rolling window.
+
+  Fixed at `10`.
+</ConfigField>
+
+<ConfigField title="enforce" type="boolean" defaultValue="true">
+  Determines if the circuit breaker is active. 
+  
+  If `false`, the circuit breaker never trips, and no requests are rejected.
+</ConfigField>
+
+## Examples
+
+### Basic Example
+
+This example configuration sets up an endpoint (`hotdog.ngrok.app`) that allows 
+only 1 request every 60 seconds and trips the circuit breaker for 2 minutes.
+
+#### Example Traffic Policy Document
+
+<CodeGroup>
+```yaml policy.yml highlight={3-9}
+on_http_request:
+  - actions:
+    - type: "circuit-breaker"
+      config:
+        error_threshold: 0
+        volume_threshold: 1
+        window_duration: "60s"
+        tripped_duration: "2m"
+        enforce: true
+```
+```json policy.json highlight={5-14}
+{
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "circuit-breaker",
+          "config": {
+            "error_threshold": 0,
+            "volume_threshold": 1,
+            "window_duration": "60s",
+            "tripped_duration": "2m",
+            "enforce": true
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+#### Start Endpoint with Traffic Policy
+
+```bash
+ngrok http 8080 --url hotdog.ngrok.app --traffic-policy-file /path/to/policy.yml
+```
+
+#### Helper script
+
+```python circuit_breaker.py
+import requests
+import time
 
 
+url = "https://hotdog.ngrok.app"
 
-<ActionOverview />
-<ActionConfig />
-<ActionBehavior />
-<ActionExamples />
+attempt = 1
+
+while True:
+    try:
+        response = requests.get(url)
+
+        # Log the response
+        if response.status_code == 200:
+            print(f"Attempt {attempt}: Success ({response.status_code})")
+        else:
+            print(f"Attempt {attempt}: Failure ({response.status_code})")
+
+        # Stop when circuit breaker trips
+        if response.status_code == 503:
+            print("\nCircuit breaker tripped!")
+            break
+    except requests.exceptions.RequestException as e:
+        print(f"Attempt {attempt}: Error ({e})")
+        break
+
+    attempt += 1
+    time.sleep(0.01)  # Reduce delay for faster request rate
+```
+
+```bash
+➜  ~ python3  circuit_breaker.py
+Attempt 1: Success (200)
+Attempt 2: Failure (503)
+
+Circuit breaker tripped!
+```
 
 ## Action Result Variables
 
-<ActionVariablesDescription />
-<ActionVariables />
+The following variables are made available for use in subsequent expressions and
+CEL interpolations after the action has run. Variable values will only apply
+to the last action execution, results are not concatenated.
+
+<Note>This action does not expose any result variables.</Note>

--- a/traffic-policy/actions/close-connection.mdx
+++ b/traffic-policy/actions/close-connection.mdx
@@ -1,21 +1,83 @@
 ---
-title: Close Connection
+title: Close Connection Action
+sidebarTitle: Close Connection
+description: Forcibly close connections to an endpoint.
 ---
-import ActionBehavior from "/snippets/traffic-policy/actions/close-connection/behavior.mdx";
-import ActionConfig from "/snippets/traffic-policy/actions/close-connection/config.mdx";
-import ActionExamples from "/snippets/traffic-policy/actions/close-connection/examples/index.mdx";
-import ActionOverview from "/snippets/traffic-policy/actions/close-connection/index.mdx";
-import ActionVariables from "/snippets/traffic-policy/actions/close-connection/variables.mdx";
-import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
+import { ConfigField } from "/snippets/ConfigTable.jsx";
+
+The Close Connection Traffic Policy action lets you forcibly close connections 
+to an endpoint when certain conditions are met, for example, when the number of 
+requests exceeds a given limit (to mitigate DDoS attacks).
+
+This action can be used with other actions such as [rate-limit](/traffic-policy/actions/rate-limit) and [deny](/traffic-policy/actions/deny).
 
 
+## Configuration Reference
 
-<ActionOverview />
-<ActionConfig />
-<ActionBehavior />
-<ActionExamples />
+The [Traffic Policy](/traffic-policy/) configuration reference for this action.
+
+### Supported Phases
+
+`on_http_request`, `on_tcp_connect`
+
+### Type
+
+`close-connection`
+
+### Configuration Fields
+
+<Note>This action does not have any configuration fields.</Note>
+
+## Behavior
+
+When this action is executed, connection to the endpoint is closed immediately.
+
+This can be useful for dealing with DDoS attacks.
+
+## Examples
+
+### Basic Example
+
+This basic example configuration will guide you through setting up an endpoint on ngrok (`hotdog.ngrok.app`) and closing the connection to the endpoint.
+
+<Steps>
+  <Step title="Save the following traffic policy document to a file called policy.yml">
+    ```yaml policy.yml
+    on_http_request:
+    - name: "Immediately close connection"
+      expressions:
+        - req.url.path.startsWith("/dc")
+      actions:
+        - type: close-connection
+    ```
+  </Step>
+
+  <Step title="Start the endpoint with the traffic policy">
+    ```bash
+    ngrok http 8080 --url hotdog.ngrok.app --traffic-policy-file ./policy.yml
+    ```
+  </Step>
+
+  <Step title="Send a request to the endpoint">
+    ```bash
+    curl http://hotdog.ngrok.app/dc
+    ```
+
+    You should see something similar to the following:
+
+    ```bash
+    curl: (16) Error in the HTTP2 framing layer
+    ```
+
+    This is expected as the connection is closed immediately.
+  </Step>
+</Steps>
 
 ## Action Result Variables
 
-<ActionVariablesDescription />
-<ActionVariables />
+The following variables are made available for use in subsequent expressions and
+CEL interpolations after the action has run. Variable values will only apply
+to the last action execution, results are not concatenated.
+
+
+<Note>This action does not set any variables after it has been executed.</Note>

--- a/traffic-policy/actions/compress-response.mdx
+++ b/traffic-policy/actions/compress-response.mdx
@@ -1,21 +1,180 @@
 ---
-title: Compress Response
+title: Compress Response Action
+sidebarTitle: Compress Response
+description: Compress HTTP response bodies before they are returned to the client.
 ---
-import ActionBehavior from "/snippets/traffic-policy/actions/compress-response/behavior.mdx";
-import ActionConfig from "/snippets/traffic-policy/actions/compress-response/config.mdx";
-import ActionExamples from "/snippets/traffic-policy/actions/compress-response/examples/index.mdx";
-import ActionOverview from "/snippets/traffic-policy/actions/compress-response/index.mdx";
-import ActionVariables from "/snippets/traffic-policy/actions/compress-response/variables.mdx";
-import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
+import { ConfigField, ConfigEnum, ConfigEnumOption } from "/snippets/ConfigTable.jsx";
 
+The Compress Response Traffic Policy action enables you to improve the
+performance of your web applications by compressing HTTP response bodies returned
+by your upstream service.
 
+## Configuration Reference
 
-<ActionOverview />
-<ActionConfig />
-<ActionBehavior />
-<ActionExamples />
+The [Traffic Policy](/traffic-policy/) configuration
+reference for this action.
+
+### Supported Phases
+
+`on_http_response`
+
+### Type
+
+`compress-response`
+
+### Configuration Fields
+
+<ConfigField title="algorithms" type="array of strings" defaultValue="['gzip', 'deflate', 'br', 'compress']">
+  <p>
+    A list of allowed compression algorithms to be considered during encoding
+    type negotiation. Each element must be unique.
+  </p>
+
+  <ConfigEnum label="Supported algorithms">
+    <ConfigEnumOption>`br`</ConfigEnumOption>
+    <ConfigEnumOption>`compress`</ConfigEnumOption>
+    <ConfigEnumOption>`deflate`</ConfigEnumOption>
+    <ConfigEnumOption>`gzip`</ConfigEnumOption>
+  </ConfigEnum>
+</ConfigField>
+
+## Behavior
+
+When an HTTP request includes an `Accept-Encoding` header, HTTP responses are
+automatically compressed, and a Content-Encoding header is added to the
+response.
+
+If the response is already compressed by your upstream service,
+no additional compression will be applied.
+
+### Streaming Compression
+
+When compression is applied, the response body is not buffered; it is
+compressed in real-time as it streams through the ngrok endpoint.
+
+### Algorithm Choice
+
+If a request specifies `Accept-Encoding` but none of the requested algorithms
+are supported, no compression is applied, and the upstream response is returned
+unmodified.
+
+### Quality Values
+
+Compression is negotiated based on the `Accept-Encoding` header as defined by
+the [RFC](https://datatracker.ietf.org/doc/html/rfc9110#name-accept-encoding),
+respecting q-values and selecting the supported algorithm with the highest
+q-value.
+
+For example:
+
+```bash
+Accept-Encoding: gzip;q=1.0, br; q=0.5, *;q=0
+```
+
+The algorithm `gzip` would be selected because it has the highest q-value of `1.0`.
+
+### Response Headers
+
+When this action performs compression, the following changes are made to the
+HTTP response headers:
+
+- The `Content-Length` header is removed.
+- A `Content-Encoding` header is added, specifying the negotiated algorithm.
+- A `Vary: Accept-Encoding` header is added to indicate that the response varies
+  based on the `Accept-Encoding` request header.
+
+## Examples
+
+### Compressing API Responses Based on URL Path
+
+The following [Traffic Policy](/traffic-policy/)
+configuration demonstrates how to set this up using the `compress-response`
+action with an expression to compress traffic on specific URL paths.
+
+#### Example Traffic Policy Document
+
+<CodeGroup>
+```yaml policy.yml highlight={4-12}
+on_http_response:
+  - expressions:
+      - "req.url.path.startsWith('/api/')"
+    actions:
+      - type: "compress-response"
+        config:
+          algorithms:
+            - "gzip"
+            - "br"
+            - "deflate"
+            - "compress"
+```
+```json policy.json highlight={8-18}
+{
+  "on_http_response": [
+    {
+      "expressions": [
+        "req.url.path.startsWith('/api/')"
+      ],
+      "actions": [
+        {
+          "type": "compress-response",
+          "config": {
+            "algorithms": [
+              "gzip",
+              "br",
+              "deflate",
+              "compress"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+For this example, we are assuming that an ngrok agent is pointing at the
+upstream service https://jsonplaceholder.typicode.com.
+
+#### Example Request
+
+```bash
+$ curl -i https://jsonplaceholder.ngrok.app/api/posts
+```
+
+```http
+HTTP/2 200 OK
+content-encoding: gzip
+content-type: application/json; charset=utf-8
+
+<compressed-body-here>
+```
+
+In this example, when a request is made to `/api/posts`,
+ngrok compresses the response using one of the specified algorithms
+(e.g., `gzip`). The response includes the `content-encoding: gzip` header, and
+the body is compressed accordingly.
+
+This setup ensures that only API responses
+for paths starting with `/api/` are compressed, enhancing performance and
+responsiveness for only those endpoints.
 
 ## Action Result Variables
 
-<ActionVariablesDescription />
-<ActionVariables />
+The following variables are made available for use in subsequent expressions and
+CEL interpolations after the action has run. Variable values will only apply
+to the last action execution, results are not concatenated.
+
+<ConfigField title="actions.ngrok.compress.already_compressed" type="boolean">
+  <p>
+    Indicates whether the body was already compressed before the action was
+    applied. Returns <code>true</code> if no further compression was
+    performed.
+  </p>
+</ConfigField>
+<ConfigField title="actions.ngrok.compress.negotiated_algorithm" type="string">
+  <p>
+    The compression algorithm selected and applied by the action, based on the
+    client's request and action configuration.
+  </p>
+</ConfigField>


### PR DESCRIPTION
Begin refactoring traffic policy actions, consolidating away from snippets and directly into the main `.mdx` files. Also introduce a new `ConfigField` React component similar to the `FieldParam` component in mintlify to standardize the display of our configuration reference fields. 

The idea here is to improve clarity, maintainability, and consistency of the documentation around actions.

One of the major issues that I was slowly resolving as I was porting things over was the code snippets in actions are all broken.