### PR TITLE
Renaming menu items, restructuring the order of sections

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -745,16 +745,7 @@
         "tab": "Reference",
         "menu": [
           {
-            "item": "SDKs",
-            "pages": [
-              "getting-started/javascript",
-              "getting-started/go",
-              "getting-started/python",
-              "getting-started/rust"
-            ]
-          },
-          {
-            "item": "API Documentation",
+            "item": "API",
             "pages": [
               "api/index",
 
@@ -876,18 +867,36 @@
             ]
           },
           {
-            "item": "CLI Reference",
+            "item": "Agent CLI",
             "pages": [
-              "getting-started/index",
-              "getting-started/cloud-endpoints-quickstart"
+              "agent",
+              "agent/cli",
+              "agent/cli-api",
+              "agent/ssh-reverse-tunnel-agent",
+              "agent/connect-url",
+              "agent/agent-tls-termination",
+              "agent/agent-mutual-tls-termination",
+              "agent/changelog",
+              "agent/version-support-policy",
+              "agent/diagnose",
+              "agent/upgrade-v2-v3"
             ]
           },
           {
-            "item": "Configuration File Reference",
+            "item": "Agent Config File",
             "pages": [
               "agent/config/index",
               "agent/config/v2",
               "agent/config/v3"
+            ]
+          },
+          {
+            "item": "SDKs",
+            "pages": [
+              "getting-started/javascript",
+              "getting-started/go",
+              "getting-started/python",
+              "getting-started/rust"
             ]
           },
           {
@@ -899,10 +908,6 @@
       {
         "tab": "Resources",
         "menu": [
-          {
-            "item": "Getting Started",
-            "pages": ["getting-started/index"]
-          },
           {
             "item": "Pricing & Limits",
             "pages": [


### PR DESCRIPTION
Renaming menu items, restructuring the order of sections, and expanding the content under the Agent-related documentation.

* Renamed `API Documentation` to `API` for a more concise menu label.
* Expanded and renamed `CLI Reference` to `Agent CLI`, adding several new Agent-related pages for deeper coverage.
* Renamed `Configuration File Reference` to `Agent Config File` and grouped relevant configuration pages under it.
* Moved the `SDKs` section further down in the menu for better sorting.
* Removed the `Getting Started` section from the `Resources` tab to streamline the navigation.